### PR TITLE
Port all the images to the QED-based docker hub

### DIFF
--- a/base_images/base-kobos/Dockerfile
+++ b/base_images/base-kobos/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base:latest
+FROM qeddockerhub/kt-base:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 

--- a/base_images/base-mongo/Dockerfile
+++ b/base_images/base-mongo/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base:latest
+FROM qeddockerhub/kt-base:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 

--- a/base_images/base-nginx/Dockerfile
+++ b/base_images/base-nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base:latest
+FROM qeddockerhub/kt-base:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 

--- a/base_images/base-rabbit/Dockerfile
+++ b/base_images/base-rabbit/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base:latest
+FROM qeddockerhub/kt-base:latest
 
 RUN echo 'deb http://www.rabbitmq.com/debian/ testing main'> /etc/apt/sources.list.d/rabbitmq.list && \
     curl -s https://www.rabbitmq.com/rabbitmq-release-signing-key.asc | apt-key add - && \

--- a/base_images/mongo/Dockerfile
+++ b/base_images/mongo/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base-mongo:latest
+FROM qeddockerhub/kt-base-mongo:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 

--- a/base_images/nginx/Dockerfile
+++ b/base_images/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base-nginx:latest
+FROM qeddockerhub/kt-base-nginx:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 

--- a/base_images/postgres/Dockerfile
+++ b/base_images/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/postgres_base:latest
+FROM qeddockerhub/kt-base-postgres:latest
 
 # Copy over the config. files.
 COPY pg_hba.conf postgresql.conf /etc/postgresql/9.4/main/

--- a/base_images/postgres_base/Dockerfile
+++ b/base_images/postgres_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base:latest
+FROM qeddockerhub/kt-base:latest
 
 # Copy over the list of `apt` requirements and install them using Postgres's repo.
 RUN mkdir -p /srv/tmp

--- a/base_images/rabbit/Dockerfile
+++ b/base_images/rabbit/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/base-rabbit:latest
+FROM qeddockerhub/kt-base-rabbit:latest
 
 COPY run_rabbit /etc/service/rabbit/run
 COPY run_rabbit-configure /etc/service/rabbit-configure/run

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,5 +1,6 @@
+# vim: set ts=2 sts=2 sw=2:
 rabbit:
-  image: kobotoolbox/rabbit:latest
+  image: qeddockerhub/kt-rabbit:latest
   # Dev: Build the image locally.
   # build: ./base_images/rabbit
   hostname: rabbit
@@ -10,7 +11,7 @@ rabbit:
   restart: on-failure
 
 postgres:
-  image: kobotoolbox/postgres:latest
+  image: qeddockerhub/kt-postgres:latest
   # Dev: Build the image locally.
   # build: ./base_images/postgres
   hostname: postgres
@@ -23,7 +24,7 @@ postgres:
   restart: on-failure
 
 mongo:
-  image: kobotoolbox/mongo:latest
+  image: qeddockerhub/kt-mongo:latest
   # Dev: Build the image locally.
   # build: ./base_images/mongo
   hostname: mongo
@@ -115,7 +116,7 @@ kpi:
   restart: on-failure
 
 nginx:
-  image: kobotoolbox/nginx:latest
+  image: qeddockerhub/kt-nginx:latest
   # Dev: Build the image locally.
   # build: ./base_images/nginx
   hostname: nginx
@@ -144,9 +145,10 @@ nginx:
     - enketo_express
   restart: on-failure
 
-# Adapted from https://github.com/kobotoolbox/enketo-express/blob/docker/docker-compose.yml.
+# Adapted from https://github.com/kobotoolbox/enketo-express/blob/master/setup/docker/docker-compose.yml
+# TODO: consider switching to qeddockerhub/enketo-express-extra-widgets
 enketo_express:
-  image: kobotoolbox/enketo_express
+  image: qeddockerhub/enketo_express:latest
   # Dev: Build the image locally.
   # build: ../enketo-express/
   env_file:
@@ -166,7 +168,7 @@ enketo_express:
     # Dev: Use the live `enketo-express` directory from the host machine.
     # - ../enketo-express:/srv/src/enketo_express
 
-# Adapted from https://github.com/kobotoolbox/enketo-express/blob/docker/docker-compose.yml.
+# Adapted from https://github.com/kobotoolbox/enketo-express/blob/master/setup/docker/docker-compose.yml
 redis_main:
   image: redis:2.6
   # Map our "main" Redis config into the container.
@@ -175,7 +177,7 @@ redis_main:
     - ./.vols/redis_main_data/:/data/
   restart: on-failure
 
-# Adapted from https://github.com/kobotoolbox/enketo-express/blob/docker/docker-compose.yml.
+# Adapted from https://github.com/kobotoolbox/enketo-express/blob/master/setup/docker/docker-compose.yml
 redis_cache:
   image: redis:2.6
   # Map our "cache" Redis config into the container.

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,7 +1,8 @@
+# vim: set ts=2 sts=2 sw=2:
 # For public, HTTPS servers.
 
 rabbit:
-  image: kobotoolbox/rabbit:latest
+  image: qeddockerhub/kt-rabbit:latest
   # Dev: Build the image locally.
   # build: ./base_images/rabbit
   hostname: rabbit
@@ -12,7 +13,7 @@ rabbit:
   restart: unless-stopped
 
 postgres:
-  image: kobotoolbox/postgres:latest
+  image: qeddockerhub/kt-postgres:latest
   # Dev: Build the image locally.
   # build: ./base_images/postgres
   hostname: postgres
@@ -25,7 +26,7 @@ postgres:
   restart: unless-stopped
 
 mongo:
-  image: kobotoolbox/mongo:latest
+  image: qeddockerhub/kt-mongo:latest
   # Dev: Build the image locally.
   # build: ./base_images/mongo
   hostname: mongo
@@ -131,7 +132,7 @@ kpi:
   #   - 'kc-local.kobotoolbox.org:172.17.0.1'
 
 nginx:
-  image: kobotoolbox/nginx:latest
+  image: qeddockerhub/kt-nginx:latest
   # Dev: Build the image locally.
   # build: ./base_images/nginx
   hostname: nginx
@@ -159,9 +160,10 @@ nginx:
     - enketo_express
   restart: unless-stopped
 
-# Adapted from https://github.com/kobotoolbox/enketo-express/blob/docker/docker-compose.yml.
+# Adapted from https://github.com/kobotoolbox/enketo-express/blob/master/setup/docker/docker-compose.yml
+# TODO: consider switching to qeddockerhub/enketo-express-extra-widgets
 enketo_express:
-  image: kobotoolbox/enketo_express
+  image: qeddockerhub/enketo_express:latest
   # Dev: Build the image locally.
   # build: ../enketo-express/
   env_file:
@@ -187,7 +189,7 @@ enketo_express:
   #   - 'kf-local.kobotoolbox.org:172.17.0.1'
   #   - 'kc-local.kobotoolbox.org:172.17.0.1'
 
-# Adapted from https://github.com/kobotoolbox/enketo-express/blob/docker/docker-compose.yml.
+# Adapted from https://github.com/kobotoolbox/enketo-express/blob/master/setup/docker/docker-compose.yml
 redis_main:
   image: redis:2.6
   # Map our "main" Redis config into the container.
@@ -196,7 +198,7 @@ redis_main:
     - ./.vols/redis_main_data/:/data/
   restart: unless-stopped
 
-# Adapted from https://github.com/kobotoolbox/enketo-express/blob/docker/docker-compose.yml.
+# Adapted from https://github.com/kobotoolbox/enketo-express/blob/master/setup/docker/docker-compose.yml
 redis_cache:
   image: redis:2.6
   # Map our "cache" Redis config into the container.


### PR DESCRIPTION
In order to provide more stable infrastructure, we need to use our own imags for all of the applications. Before merging this PR, we need to make sure that all of the images on docker hub are already built.